### PR TITLE
match bbx black with common black

### DIFF
--- a/boombox/index.js
+++ b/boombox/index.js
@@ -2,9 +2,5 @@ exports = module.exports = require('../');
 
 exports.color = exports.color || {};
 
-exports.color.black = 'hsl(210, 24%, 13%)';
-exports.color.blue = 'hsl(220, 73%, 59%)';
-exports.color.charcoal = 'hsl(210, 17%, 25%)';
-
-exports.color.primary = exports.color.blue;
-exports.color.accent = exports.color.blue;
+exports.color.primary = exports.color.royal;
+exports.color.accent = exports.color.royal;

--- a/index.js
+++ b/index.js
@@ -31,22 +31,21 @@ out.containerWidth = '672px';
 out.color = {};
 
 out.color.azure = 'hsl(234, 42%, 95%)';
-out.color.red = 'hsl(2, 69%, 59%)';
-out.color.orange = 'hsl(35, 80%, 58%)';
-out.color.yellow = 'hsl(49, 75%, 50%)';
-out.color.green = 'hsl(154, 48%, 54%)';
-out.color.lightGreen = 'hsl(76, 58%, 61%)';
+out.color.black = 'hsl(210, 24%, 13%)';
 out.color.blue = 'hsl(220, 60%, 62%)';
+out.color.charcoal = 'hsl(210, 17%, 25%)';
 out.color.cyan = 'hsl(181, 48%, 58%)';
-out.color.violet = 'hsl(271, 54%, 58%)';
-
-out.color.white = 'hsl(234, 42%, 100%)';
-out.color.silver = 'hsl(204, 9%, 89%)';
 out.color.gray = 'hsl(210, 11%, 47%)';
 out.color.grayBlue = 'hsl(210, 15%, 33%)';
-out.color.charcoal = 'hsl(210, 17%, 25%)';
-out.color.black = 'hsl(210, 6%, 14%)';
-
+out.color.green = 'hsl(154, 48%, 54%)';
+out.color.lightGreen = 'hsl(76, 58%, 61%)';
+out.color.orange = 'hsl(35, 80%, 58%)';
+out.color.red = 'hsl(2, 69%, 59%)';
+out.color.royal = 'hsl(220, 73%, 59%)';
+out.color.silver = 'hsl(204, 9%, 89%)';
+out.color.violet = 'hsl(271, 54%, 58%)';
+out.color.white = 'hsl(234, 42%, 100%)';
+out.color.yellow = 'hsl(49, 75%, 50%)';
 
 out.color.primary = out.color.red;
 out.color.accent = out.color.cyan;


### PR DESCRIPTION
alphabetized colors
charcoal was the same in the branding/index.js as what was in boombox
changed black to match boombox branded black
changed boombox to use royal so it can be available everywhere

brands should not set colors, but use colors to set primary and accent colors
